### PR TITLE
fixed objdump usage under non English locale

### DIFF
--- a/make-sqldeveloper-package
+++ b/make-sqldeveloper-package
@@ -644,7 +644,7 @@ func_reorganize() {
 		local LIBWORKDIR="${1}/${LIBSDIR}"
 
 		for Library in $(${FIND} "${OPTDIR}" ! \( -type d -o -name "*.jar" \) |${XARGS} ${XARGS_OPTS} ${FILE} ${FILE_OPTS} |${GREP} ${GREP_OPTS} "ELF (32|64)-bit LSB shared object" |${CUT} ${CUT_OPTS_FN}) ; do
-			local ARCH="$(${OBJDUMP} ${OBJDUMP_OPTS_FUNC_REORG} ${Library} |${GREP} ${GREP_OPTS} "file format" |${SED} ${SED_OPTS} 's/^.*file format //' |${CUT} ${CUT_OPTS_LIB} |${TR} ${TR_OPTS} - _)"
+			local ARCH="$(LC_ALL=C ${OBJDUMP} ${OBJDUMP_OPTS_FUNC_REORG} ${Library} |${GREP} ${GREP_OPTS} "file format" |${SED} ${SED_OPTS} 's/^.*file format //' |${CUT} ${CUT_OPTS_LIB} |${TR} ${TR_OPTS} - _)"
 			local SONAME="$(${OBJDUMP} ${OBJDUMP_OPTS_FUNC_REORG} ${Library} |${GREP} ${GREP_OPTS} "SONAME" |${SED} ${SED_OPTS} 's/^[[:space:]]*SONAME[[:space:]]*//')"
 			SONAME=${SONAME##*/}
 			local SERIAL="$(printf ${Library##*/} |${SED} ${SED_OPTS} 's/\.so*$//' |${CUT} ${CUT_OPTS_LIB})"


### PR DESCRIPTION
Running `objdump` under a non English locale may produce different results, as the "file format" string may be localized.

Because of this, the ARCH variable will not be initialized correctly:

    + objdump -p /tmp/tmp.upd5ASPK50/sqldeveloper-17.4.1.054.0712/usr/share/sqldeveloper/netbeans/platform/modules/lib/amd64/linux/libjnidispatch-422.so
    + grep -E file format
    + sed -e s/^.*file format //
    + cut -d - -f 2-
    + tr - _
    + local ARCH=

This end up causing a failure in the `ln` invocation with the `ln: failed to create symbolic link '...': File exists` error message:

    + [ -d /tmp/tmp.upd5ASPK50/sqldeveloper-17.4.1.054.0712/usr/lib/-linux-gnu/sqldeveloper/17.4.1.054.0712 ]
    + mv --strip-trailing-slashes /tmp/tmp.upd5ASPK50/sqldeveloper-17.4.1.054.0712/usr/share/sqldeveloper/netbeans/platform/modules/lib/amd64/linux/libjnidispatch-422.so /tmp/tmp.upd5ASPK50/sqldeveloper-17.4.1.054.0712/usr/lib/-linux-gnu/sqldeveloper/17.4.1.054.0712/libjnidispatch.so.4.2.2
    + ln -s libjnidispatch.so.4.2.2 /tmp/tmp.upd5ASPK50/sqldeveloper-17.4.1.054.0712/usr/lib/-linux-gnu/sqldeveloper/17.4.1.054.0712/libjnidispatch.so

A similar issue affects other tools which make use of `objdump`; see this CMake bug: https://cmake.org/Bug/view.php?id=15002
